### PR TITLE
Use LUTs and smaller cyan markers for QC overlays

### DIFF
--- a/rnascope_pipeline/analysis.py
+++ b/rnascope_pipeline/analysis.py
@@ -13,7 +13,8 @@ from .config import Config
 from .image_utils import (
     draw_crosses_inplace,
     expand_label_mask,
-    make_rgb_background,
+    apply_orange_hot_lut,
+    apply_red_lut,
     tight_crop_nd,
     to_uint8_vis,
 )
@@ -102,10 +103,10 @@ def analyze_roi(
     # Save separate GOA and GOB overlays
     goa_bg = to_uint8_vis(cutout_masked[..., cfg.goa_index])
     gob_bg = to_uint8_vis(cutout_masked[..., cfg.gob_index])
-    goa_overlay = make_rgb_background(goa_bg)
-    gob_overlay = make_rgb_background(gob_bg)
+    goa_overlay = apply_red_lut(goa_bg)
+    gob_overlay = apply_orange_hot_lut(gob_bg)
     draw_crosses_inplace(goa_overlay, goa_x, goa_y, color=(0, 255, 255), size=cfg.spot_marker_size)
-    draw_crosses_inplace(gob_overlay, gob_x, gob_y, color=(255, 0, 0), size=cfg.spot_marker_size)
+    draw_crosses_inplace(gob_overlay, gob_x, gob_y, color=(0, 255, 255), size=cfg.spot_marker_size)
     overlay_name_goa = f"{animal}_{region}_{roi_name}_goa_maxima.png"
     overlay_name_gob = f"{animal}_{region}_{roi_name}_gob_maxima.png"
     imsave(str(cfg.qc_overlays_dir / overlay_name_goa), goa_overlay)

--- a/rnascope_pipeline/config.py
+++ b/rnascope_pipeline/config.py
@@ -42,7 +42,7 @@ class Config:
     goa_index: int = 2
     """Channel index for the GoA channel."""
 
-    spot_marker_size: int = 3
+    spot_marker_size: int = 1
     """Half size of the cross used to mark spots in overlay images."""
 
     load_saved_masks: bool = True

--- a/rnascope_pipeline/image_utils.py
+++ b/rnascope_pipeline/image_utils.py
@@ -84,6 +84,21 @@ def make_rgb_background(gray: np.ndarray) -> np.ndarray:
     return np.stack([gray, gray, gray], axis=-1)
 
 
+def apply_red_lut(gray: np.ndarray) -> np.ndarray:
+    """Map ``gray`` to a red lookup table for visualisation."""
+    zeros = np.zeros_like(gray)
+    return np.stack([gray, zeros, zeros], axis=-1)
+
+
+def apply_orange_hot_lut(gray: np.ndarray) -> np.ndarray:
+    """Map ``gray`` to an orange hot lookup table."""
+    norm = gray.astype(np.float32) / 255.0
+    r = np.clip(norm * 3.0, 0, 1)
+    g = np.clip((norm - 1.0 / 3.0) * 3.0, 0, 1)
+    rgb = np.stack([r, g, np.zeros_like(r)], axis=-1)
+    return (rgb * 255).astype(np.uint8)
+
+
 def draw_crosses_inplace(rgb: np.ndarray, xs: np.ndarray, ys: np.ndarray, *, color: tuple, size: int) -> None:
     """Draw coloured crosses onto ``rgb`` in‑place."""
     h, w, _ = rgb.shape


### PR DESCRIPTION
## Summary
- Display GoA channel overlays with red LUT and GoB overlays with orange hot LUT
- Draw cyan crosses half-sized via new spot_marker_size default
- Provide LUT helper functions for visualisation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a88a8ed9788326a19a4b1e1bab5ee1