### PR TITLE
feat: add avg spots per cell metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,11 @@ Per **ROI**:
 * ROI area (µm²)
 * Totals & densities (spots/µm²) for GoA & GoB
 * GOA:GOB ratio (NaN if GOB=0)
+* Average spots per cell for GoA & GoB (cell-associated only) and their ratio
 * Proportions: cells with more GoA/Gob, any GoA/GoB, or no spots
 * Bin counts & proportions; **H‑score** = Σ(bin × count) and normalized per cell
 
-**Overall**: same summaries pooled across all nuclei.
+**Overall**: same summaries pooled across all nuclei, including average spots per cell metrics.
 
 ---
 

--- a/rnascope_pipeline/analysis.py
+++ b/rnascope_pipeline/analysis.py
@@ -214,12 +214,19 @@ def analyze_roi(
     hscore_goa = sum(b * c for b, c in bins_goa.items())
     hscore_gob = sum(b * c for b, c in bins_gob.items())
 
+    avg_goa_per_cell = float(np.mean(goa_exp_counts)) if len(goa_exp_counts) > 0 else np.nan
+    avg_gob_per_cell = float(np.mean(gob_exp_counts)) if len(gob_exp_counts) > 0 else np.nan
+    ratio_avg_goa_gob = (
+        (avg_goa_per_cell / avg_gob_per_cell) if avg_gob_per_cell > 0 else np.nan
+    )
+
     log(
         cfg,
         "    per‑ROI: "
         f"n_cells={len(per_nucleus_rows)}, moreGOA={cells_more_goa}, "
         f"moreGOB={cells_more_gob}, noSpots={cells_no_spots}, "
-        f"Hs(GOA/GOB)={hscore_goa}/{hscore_gob}",
+        f"Hs(GOA/GOB)={hscore_goa}/{hscore_gob}, "
+        f"avg(GOA/GOB)={avg_goa_per_cell:.3f}/{avg_gob_per_cell:.3f}",
     )
 
     per_roi_row: Dict[str, float] = {
@@ -233,6 +240,9 @@ def analyze_roi(
         "GoA_density_per_um2": goa_density,
         "GoB_density_per_um2": gob_density,
         "GoA_to_GoB_ratio": ratio_goa_gob,
+        "GoA_avg_spots_per_cell": avg_goa_per_cell,
+        "GoB_avg_spots_per_cell": avg_gob_per_cell,
+        "GoA_to_GoB_avg_spot_ratio": ratio_avg_goa_gob,
         "cells_more_GoA": cells_more_goa,
         "cells_more_GoA_prop": cells_more_goa / n_cells,
         "cells_more_GoB": cells_more_gob,

--- a/rnascope_pipeline/pipeline.py
+++ b/rnascope_pipeline/pipeline.py
@@ -130,6 +130,9 @@ def run_pipeline(cfg: Config) -> None:
         total_cells = len(per_nuc_df)
         goa_all = per_nuc_df["GoA_expanded"].to_numpy(int)
         gob_all = per_nuc_df["GoB_expanded"].to_numpy(int)
+        avg_goa_all = float(goa_all.mean()) if total_cells > 0 else np.nan
+        avg_gob_all = float(gob_all.mean()) if total_cells > 0 else np.nan
+        avg_ratio_all = (avg_goa_all / avg_gob_all) if avg_gob_all > 0 else np.nan
         cells_more_goa_all = int(np.sum(goa_all > gob_all))
         cells_more_gob_all = int(np.sum(gob_all > goa_all))
         cells_no_spots_all = int(np.sum((goa_all == 0) & (gob_all == 0)))
@@ -151,6 +154,9 @@ def run_pipeline(cfg: Config) -> None:
             "cells_any_GoA_prop": cells_any_goa_all / total_cells,
             "cells_any_GoB": cells_any_gob_all,
             "cells_any_GoB_prop": cells_any_gob_all / total_cells,
+            "GoA_avg_spots_per_cell": avg_goa_all,
+            "GoB_avg_spots_per_cell": avg_gob_all,
+            "GoA_to_GoB_avg_spot_ratio": avg_ratio_all,
             "GoA_Hscore": hscore_goa_all,
             "GoA_Hscore_norm": hscore_goa_all / total_cells,
             "GoB_Hscore": hscore_gob_all,


### PR DESCRIPTION
## Summary
- compute per-ROI average GOA/GOB spots per cell and their ratio
- record overall average cell-associated spot counts for GOA/GOB with ratio
- document new metrics in README

## Testing
- `pytest`
- `python -m py_compile rnascope_pipeline/analysis.py rnascope_pipeline/pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68a99c2d6b18832693b56c40794049ce