### PR TITLE
Make GoB QC overlay orange

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ project_root/
 All results are written under `results_rnascope/` (configurable):
 
 * **`cutouts/`** – Free‑form masked ROI cutouts (outside polygon set to 0). One per polygon ROI.
-* **`qc_overlays/`** – Normalised GOA and GOB channel overlays with their respective maxima crosses (GOB=red, GOA=cyan) saved as PNG.
+* **`qc_overlays/`** – Normalised GOA (red) and GOB (orange) channel overlays with maxima crosses in cyan saved as PNG.
 * **`roi_masks_cropped/`** – Cropped polygon masks for sanity checks (binary 0/255).
 * **`masks/`** – Cellpose **labels** per polygon ROI (cached for reuse).
 * **`csv/`** – Tables:

--- a/rnascope_pipeline/image_utils.py
+++ b/rnascope_pipeline/image_utils.py
@@ -94,7 +94,9 @@ def apply_orange_hot_lut(gray: np.ndarray) -> np.ndarray:
     """Map ``gray`` to an orange hot lookup table."""
     norm = gray.astype(np.float32) / 255.0
     r = np.clip(norm * 3.0, 0, 1)
-    g = np.clip((norm - 1.0 / 3.0) * 3.0, 0, 1)
+    g = (
+        np.clip((norm - 1.0 / 3.0) * 3.0, 0, 1) * (165.0 / 255.0)
+    )  # saturate at orange (~255,165,0)
     rgb = np.stack([r, g, np.zeros_like(r)], axis=-1)
     return (rgb * 255).astype(np.uint8)
 


### PR DESCRIPTION
## Summary
- Adjust GoB orange-hot lookup table to saturate at orange instead of yellow for QC overlays
- Update README to note GoA (red) and GoB (orange) overlays with cyan maxima crosses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9a5e3c97083269d8c0c7b3bfa7109